### PR TITLE
Fix invalid descriptor URL that was preventing license key validation and license file upload

### DIFF
--- a/src/main/webapp/config.js
+++ b/src/main/webapp/config.js
@@ -1,4 +1,4 @@
-const descriptorUrl = "/jenkins/manage/descriptorByName/io.jenkins.plugins.railflow.jenkins.admin.GlobalConfig";
+const descriptorUrl = "/manage/descriptorByName/io.jenkins.plugins.railflow.jenkins.admin.GlobalConfig";
 
 function uploadLicense() {
     try {


### PR DESCRIPTION
The descriptor URL defined in config.js contained the `/jenkins` prefix which is required when launched via maven but should not be there when Jenkins is running in standalone mode.

### Testing done

Tested by running the plugin on a stand-alone instance of Jenkins.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [C] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
